### PR TITLE
pairsByKeys is not a modutil

### DIFF
--- a/checks/broken_recipe.lua
+++ b/checks/broken_recipe.lua
@@ -2,9 +2,7 @@
 
 -- If true, will also check groups
 local check_groups = true
-
-local modutils = qa_block.modutils
-local pairsByKeys = modutils.pairsByKeys
+local pairsByKeys = qa_block.pairsByKeys
 
 local known_bad_items = {}
 local known_groups = {}
@@ -36,7 +34,7 @@ end
 
 local check_item = function(itemstring, bad_item_msg, bad_group_msg, is_output)
 	local item = ItemStack(itemstring):get_name()
-	local modname = modutils.get_modname_by_itemname(item)
+	local modname = qa_block.modutils.get_modname_by_itemname(item)
 	if modname ~= "group" then
 		if not item_exists(item) and not known_bad_items[item] then
 			known_bad_items[item] = true

--- a/checks/no_sounds.lua
+++ b/checks/no_sounds.lua
@@ -2,7 +2,7 @@
 
 -- Sounds are always optional, but most nodes SHOULD have sounds for good quality.
 
-for name, def in qa_block.modutils.pairsByKeys(minetest.registered_nodes) do
+for name, def in qa_block.pairsByKeys(minetest.registered_nodes) do
 	local complaints = {}
 	local failed = false
 	-- Air and ignore are allowed to be silent

--- a/checks/redundant_items.lua
+++ b/checks/redundant_items.lua
@@ -11,7 +11,7 @@ local blacklist = {
 	wool = true,
 }
 
-for item, def in qa_block.modutils.pairsByKeys(minetest.registered_items) do
+for item, def in qa_block.pairsByKeys(minetest.registered_items) do
 	if item:find(':') then
 		local mod_name, item_name = unpack(item:split(':'))
 		if not blacklist[mod_name] and not def.groups.not_in_creative_inventory then

--- a/checks/same_recipe.lua
+++ b/checks/same_recipe.lua
@@ -131,7 +131,7 @@ local known_recipes = {}
 
 -- load and execute file each click
 --for name, def in pairs(minetest.registered_nodes) do
-for name, def in modutils.pairsByKeys(minetest.registered_items) do
+for name, def in qa_block.pairsByKeys(minetest.registered_items) do
 
 	if (not def.groups.not_in_creative_inventory or
 	   def.groups.not_in_creative_inventory == 0) and

--- a/checks/unobtainable_items.lua
+++ b/checks/unobtainable_items.lua
@@ -36,7 +36,7 @@ for item, def in pairs(minetest.registered_items) do
 	end
 end
 
-for item, obtainable in qa_block.modutils.pairsByKeys(items) do
+for item, obtainable in qa_block.pairsByKeys(items) do
 	if obtainable == false then
 		print(item)
 	end

--- a/checks/useless_items.lua
+++ b/checks/useless_items.lua
@@ -80,9 +80,9 @@ local check = function(name, def)
 	print(name)
 end
 
-for name, def in qa_block.modutils.pairsByKeys(minetest.registered_tools) do
+for name, def in qa_block.pairsByKeys(minetest.registered_tools) do
 	check(name, def)
 end
-for name, def in qa_block.modutils.pairsByKeys(minetest.registered_craftitems) do
+for name, def in qa_block.pairsByKeys(minetest.registered_craftitems) do
 	check(name, def)
 end

--- a/init.lua
+++ b/init.lua
@@ -16,9 +16,9 @@ local logfilename = minetest.get_worldpath() .. "/qa_block.log"
 -----------------------------------------------
 qa_block = {}
 qa_block.modpath = minetest.get_modpath(minetest.get_current_modname())
-local filepath = qa_block.modpath.."/checks/"
-
 qa_block.modutils = dofile(qa_block.modpath.."/modutils.lua")
+
+local checks_path = qa_block.modpath.."/checks/"
 
 --[[ --temporary buildin usage (again)
 local smartfs_enabled = false
@@ -36,13 +36,39 @@ qa_block.smartfs = smartfs
 dofile(qa_block.modpath.."/smartfs_forms.lua")
 local smartfs_enabled = true
 
+
+-----------------------------------------------
+-- Return a list of keys sorted - Useful when looking for regressions
+-- https://www.lua.org/pil/19.3.html
+-- Additional helper to be used in checks
+-----------------------------------------------
+function qa_block.pairsByKeys (t)
+	if not t then
+		return function()
+			return nil
+		end
+	end
+
+	local a = {}
+	for n in pairs(t) do table.insert(a, n) end
+	table.sort(a)
+	local i = 0      -- iterator variable
+	local iter = function ()   -- iterator function
+			i = i + 1
+			if a[i] == nil then return nil
+			else return a[i], t[a[i]]
+			end
+	end
+	return iter
+end
+
 -----------------------------------------------
 -- QA-Block functionality - list checks
 -----------------------------------------------
 qa_block.get_checks_list = function()
 	local out = {}
 	local files
-	files = minetest.get_dir_list(filepath, false)
+	files = minetest.get_dir_list(checks_path, false)
 	for f=1, #files do
 		local filename = files[f]
 		local outname, _ext = filename:match("(.*)(.lua)$")
@@ -111,7 +137,7 @@ end
 -- QA-Block functionality - get the source of a module
 -----------------------------------------------
 function qa_block.get_source(check)
-	local file = filepath..check..".lua"
+	local file = checks_path..check..".lua"
 	local f=io.open(file,"r")
 	if not f then
 		return ""

--- a/modutils.lua
+++ b/modutils.lua
@@ -68,29 +68,4 @@ function modutils.get_depend_checker(modname)
 	return self
 end
 
------------------------------------------------
--- Return a list of keys sorted - Useful when looking for regressions
--- https://www.lua.org/pil/19.3.html
------------------------------------------------
-function modutils.pairsByKeys (t)
-	if not t then
-		return function()
-			return nil
-		end
-	end
-
-	local a = {}
-	for n in pairs(t) do table.insert(a, n) end
-	table.sort(a)
-	local i = 0      -- iterator variable
-	local iter = function ()   -- iterator function
-			i = i + 1
-			if a[i] == nil then return nil
-			else return a[i], t[a[i]]
-			end
-	end
-	return iter
-end
-
-
 return modutils


### PR DESCRIPTION
Hi! Since my last comment was ignored, I prepared a commit on top of your development. 
modutils is an "external library" around mods dependencies analysis. The pairsByKeys is not related to the mods.

I moved the pairsByKeys to qa_block.pairsByKeys and did some other small adjustments.